### PR TITLE
Update EntityInputDeriver.php : Remove unused use statement.

### DIFF
--- a/src/Plugin/Deriver/InputTypes/EntityInputDeriver.php
+++ b/src/Plugin/Deriver/InputTypes/EntityInputDeriver.php
@@ -9,7 +9,6 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\graphql\Utility\StringHelper;
-use Drupal\graphql_content_mutation\ContentEntityMutationSchemaConfig;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class EntityInputDeriver extends DeriverBase implements ContainerDeriverInterface {


### PR DESCRIPTION
ContentEntityMutationSchemaConfig is not used, and also not in this module or its dependencies.